### PR TITLE
feat(message): 메시지 엔티티 클래스 및 ORM 매핑 구현

### DIFF
--- a/src/main/java/study/yim0327/spring_chat/entity/ChatMessage.java
+++ b/src/main/java/study/yim0327/spring_chat/entity/ChatMessage.java
@@ -1,0 +1,59 @@
+package study.yim0327.spring_chat.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "chat_message")
+public class ChatMessage {
+
+    /** 메시지 PK */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_id", nullable = false)
+    private Long id;
+
+    /** 송신자 닉네임 스냅샷 */
+    @Column(name = "sender", nullable = false, length = 20)
+    private String sender;
+
+    /** 메시지 내용 */
+    @Column(name = "content", nullable = false, length = 500)
+    private String content;
+
+    /** 메시지 입력 시각 */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * 채팅방 (N:1)
+     * - 여러 메시지가 하나의 채팅방에 속함
+     * - 외래키(FK): room_id
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE) // 방 삭제 시 함께 삭제
+    private ChatRoom chatRoom;
+
+    /**
+     * 세션 (N:1)
+     * - 여러 메시지가 하나의 세션에 속함
+     * - 외래키(FK): session_id
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "session_id", nullable = false)
+    private Session session;
+
+    /** 세션 저장 시 자동 타임스탬프 설정 */
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}


### PR DESCRIPTION
- message_id / sender / content / created_at / room_id(FK) / session_id(FK) 필드 정의
- `@entity`, `@table`: 객체와 테이블 매핑 / @column: 필드와 컬럼 매핑
- `@ManytoOne`으로 채팅방 및 세션과 다대일 관계 설정
- `@joincolumn`으로 각각 room_id, session_id 외래키 설정

기존 브랜치에서 잘못된 구현을 정리한 뒤, 새로 생성한 PR 입니다.