### PR TITLE
feat(util): 공통 API 응답 객체(ApiResponse) 구현

### DIFF
--- a/src/main/java/study/yim0327/spring_chat/util/ApiResponse.java
+++ b/src/main/java/study/yim0327/spring_chat/util/ApiResponse.java
@@ -1,0 +1,35 @@
+package study.yim0327.spring_chat.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 값 필드는 JSON에서 제외
+public class ApiResponse<T> {
+    private boolean success;
+    private String message;
+    private T data;
+
+    // 성공 응답 (데이터 있음)
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, message, data);
+    }
+
+    // 성공 응답 (데이터 없음)
+    public static <T> ApiResponse<T> success(String message) {
+        return new ApiResponse<>(true, message, null);
+    }
+
+    // 메시지 없이 데이터만 있는 성공 응답
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, null, data);
+    }
+
+    // 실패 응답
+    public static <T> ApiResponse<T> failure(String message) {
+        return new ApiResponse<>(false, message, null);
+    }
+
+}


### PR DESCRIPTION
- ApiResponse<T> 클래스 추가
- 성공/실패 정적 팩토리 메서드 정의 (success, failure)
- 응답 필드 구조 확립: success, message, data
- 컨트롤러에서 ResponseEntity와 함께 사용하는 기본 패턴 마련