### PR TITLE
feat(room): 채팅방 생성 및 전체 목록 조회 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Environment variable ###
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,22 @@
-FROM bellsoft/liberica-openjdk-alpine:21
-CMD ["./gradlew", "clean", "build"]
-ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} app.jar
+# 빌드 단계
+FROM gradle:8.7-jdk21 AS builder
+
+WORKDIR /app
+
+# 1. 프로젝트 전체 복사
+COPY . .
+
+# 2. Gradle 빌드
+RUN ./gradlew clean build -x test
+
+# 실행 단계
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+# 3. 빌드된 jar 복사
+COPY --from=builder /app/build/libs/*.jar app.jar
+
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM bellsoft/liberica-openjdk-alpine:21
+CMD ["./gradlew", "clean", "build"]
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+services:								#컨테이너들을 지정
+  simple-chat-server:					#컨테이너명
+    container_name: simple-chat-server
+    ports:
+      - "8080:8080"
+    image: simple-chat-server
+    networks:
+      - docker-network
+    depends_on:							#다른 컨테이너에 의존적으로 설정
+      simple-chat-db:
+        condition: service_healthy		#simple-chat-db가 healthy 상태일때만 실행
+    environment:
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
+      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+
+  simple-chat-db:						#컨테이너명
+    container_name: simple-chat-db	#컨테이너명 직접 명시
+    image: mysql:latest					#해당 컨테이너가 가질 이미지
+    restart: always						#재시작 옵션
+    volumes:							#볼륨 설정
+      - mysql_volume:/var/lib/mysql
+    environment:						#환경 변수 설정
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+    ports:								#Docker와 연결할 포트
+      - "3306:3306"
+    networks:							#컨테이너를 그룹화하는 네트워크
+      - docker-network
+    healthcheck:						#컨테이너가 healthy한지 판단할 기준
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
+
+networks:								#네트워크 생성
+  docker-network:
+    driver: bridge
+
+volumes:								#볼륨 생성
+  mysql_volume:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:								#컨테이너들을 지정
   simple-chat-server:					#컨테이너명
     container_name: simple-chat-server
+    build:
+      context: .
+      dockerfile: Dockerfile            #직접 Dockerfile 읽어서 이미지 빌드 (도커 허브 X)
     ports:
       - "8080:8080"
     image: simple-chat-server

--- a/src/main/java/study/yim0327/spring_chat/controller/ChatRoomController.java
+++ b/src/main/java/study/yim0327/spring_chat/controller/ChatRoomController.java
@@ -1,0 +1,36 @@
+package study.yim0327.spring_chat.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import study.yim0327.spring_chat.dto.ChatRoomCreateRequestDto;
+import study.yim0327.spring_chat.dto.ChatRoomCreateResponseDto;
+import study.yim0327.spring_chat.dto.ChatRoomSearchResponseDto;
+import study.yim0327.spring_chat.service.ChatRoomService;
+import study.yim0327.spring_chat.util.ApiResponse;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/rooms")
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    /** 채팅방 생성 */
+    @PostMapping
+    public ResponseEntity<ApiResponse<ChatRoomCreateResponseDto>> createRoom(@Valid @RequestBody ChatRoomCreateRequestDto request) {
+        ChatRoomCreateResponseDto response = chatRoomService.createRoom(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /** 전체 채팅방 목록 조회 */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ChatRoomSearchResponseDto>>> getAllRooms() {
+        List<ChatRoomSearchResponseDto> rooms = chatRoomService.getAllRooms();
+        return ResponseEntity.ok(ApiResponse.success(rooms));
+    }
+
+}

--- a/src/main/java/study/yim0327/spring_chat/controller/SessionController.java
+++ b/src/main/java/study/yim0327/spring_chat/controller/SessionController.java
@@ -1,0 +1,30 @@
+package study.yim0327.spring_chat.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import study.yim0327.spring_chat.dto.NicknameRegisterRequestDto;
+import study.yim0327.spring_chat.dto.NicknameRegisterResponseDto;
+import study.yim0327.spring_chat.service.SessionService;
+import study.yim0327.spring_chat.util.ApiResponse;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class SessionController {
+
+    private final SessionService sessionService;
+
+    @PostMapping("/sessions")
+    public ResponseEntity<ApiResponse<NicknameRegisterResponseDto>> registerNickname(@Valid @RequestBody NicknameRegisterRequestDto request) {
+        NicknameRegisterResponseDto response =
+                sessionService.register(request.getRoomId(), request.getNickname());
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+}

--- a/src/main/java/study/yim0327/spring_chat/dto/ChatRoomCreateRequestDto.java
+++ b/src/main/java/study/yim0327/spring_chat/dto/ChatRoomCreateRequestDto.java
@@ -1,0 +1,11 @@
+package study.yim0327.spring_chat.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ChatRoomCreateRequestDto {
+
+    @NotBlank
+    private String roomName;
+}

--- a/src/main/java/study/yim0327/spring_chat/dto/ChatRoomCreateResponseDto.java
+++ b/src/main/java/study/yim0327/spring_chat/dto/ChatRoomCreateResponseDto.java
@@ -1,0 +1,16 @@
+package study.yim0327.spring_chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomCreateResponseDto {
+
+    private Long roomId;
+    private String roomName;
+    private String roomCode;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/study/yim0327/spring_chat/dto/ChatRoomSearchResponseDto.java
+++ b/src/main/java/study/yim0327/spring_chat/dto/ChatRoomSearchResponseDto.java
@@ -1,0 +1,17 @@
+package study.yim0327.spring_chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomSearchResponseDto {
+
+    private Long roomId;
+    private String roomName;
+    private String roomCode;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/study/yim0327/spring_chat/dto/NicknameRegisterRequestDto.java
+++ b/src/main/java/study/yim0327/spring_chat/dto/NicknameRegisterRequestDto.java
@@ -1,0 +1,15 @@
+package study.yim0327.spring_chat.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+@Getter
+public class NicknameRegisterRequestDto {
+    @Positive
+    private Long roomId;
+
+    @NotBlank
+    private String nickname;
+
+}

--- a/src/main/java/study/yim0327/spring_chat/dto/NicknameRegisterResponseDto.java
+++ b/src/main/java/study/yim0327/spring_chat/dto/NicknameRegisterResponseDto.java
@@ -1,4 +1,14 @@
 package study.yim0327.spring_chat.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class NicknameRegisterResponseDto {
+
+    private Long sessionId;
+    private String clientId;
+    private Long roomId;
+    private String nickname;
 }

--- a/src/main/java/study/yim0327/spring_chat/dto/NicknameRegisterResponseDto.java
+++ b/src/main/java/study/yim0327/spring_chat/dto/NicknameRegisterResponseDto.java
@@ -1,0 +1,4 @@
+package study.yim0327.spring_chat.dto;
+
+public class NicknameRegisterResponseDto {
+}

--- a/src/main/java/study/yim0327/spring_chat/entity/ActiveNickname.java
+++ b/src/main/java/study/yim0327/spring_chat/entity/ActiveNickname.java
@@ -2,10 +2,12 @@ package study.yim0327.spring_chat.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(
@@ -36,5 +38,12 @@ public class ActiveNickname {
     @JoinColumn(name = "room_id", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE) // 방 삭제 시 함께 삭제
     private ChatRoom chatRoom;
+
+    public static ActiveNickname create(String nickname, ChatRoom chatRoom) {
+        ActiveNickname an = new ActiveNickname();
+        an.activeNickname = nickname;
+        an.chatRoom = chatRoom;
+        return an;
+    }
 
 }

--- a/src/main/java/study/yim0327/spring_chat/entity/ChatMessage.java
+++ b/src/main/java/study/yim0327/spring_chat/entity/ChatMessage.java
@@ -1,0 +1,59 @@
+package study.yim0327.spring_chat.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "chat_message")
+public class ChatMessage {
+
+    /** 메시지 PK */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_id", nullable = false)
+    private Long id;
+
+    /** 송신자 닉네임 스냅샷 */
+    @Column(name = "sender", nullable = false, length = 20)
+    private String sender;
+
+    /** 메시지 내용 */
+    @Column(name = "content", nullable = false, length = 500)
+    private String content;
+
+    /** 메시지 입력 시각 */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * 채팅방 (N:1)
+     * - 여러 메시지가 하나의 채팅방에 속함
+     * - 외래키(FK): room_id
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE) // 방 삭제 시 함께 삭제
+    private ChatRoom chatRoom;
+
+    /**
+     * 세션 (N:1)
+     * - 여러 메시지가 하나의 세션에 속함
+     * - 외래키(FK): session_id
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "session_id", nullable = false)
+    private Session session;
+
+    /** 세션 저장 시 자동 타임스탬프 설정 */
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/study/yim0327/spring_chat/entity/ChatRoom.java
+++ b/src/main/java/study/yim0327/spring_chat/entity/ChatRoom.java
@@ -2,10 +2,12 @@ package study.yim0327.spring_chat.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "chat_room")

--- a/src/main/java/study/yim0327/spring_chat/entity/ChatRoom.java
+++ b/src/main/java/study/yim0327/spring_chat/entity/ChatRoom.java
@@ -48,4 +48,11 @@ public class ChatRoom {
         this.updatedAt = LocalDateTime.now();
     }
 
+    public static ChatRoom create(String roomName, String roomCode) {
+        ChatRoom room = new ChatRoom();
+        room.roomName = roomName;
+        room.roomCode = roomCode;
+        return room;
+    }
+
 }

--- a/src/main/java/study/yim0327/spring_chat/entity/Session.java
+++ b/src/main/java/study/yim0327/spring_chat/entity/Session.java
@@ -2,6 +2,7 @@ package study.yim0327.spring_chat.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
  * 세션
  * - WebSocket 연결 1회를 나타냄 (브라우저 탭 단위)
  */
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "session")
@@ -60,6 +62,13 @@ public class Session {
     public void disconnect() {
         this.disconnectedAt = LocalDateTime.now();
         this.active = false;
+    }
+
+    public static Session create(String clientId, ActiveNickname activeNickname) {
+        Session s = new Session();
+        s.clientId = clientId;
+        s.activeNickname = activeNickname;
+        return s;
     }
 
 }

--- a/src/main/java/study/yim0327/spring_chat/exception/GlobalExceptionHandler.java
+++ b/src/main/java/study/yim0327/spring_chat/exception/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package study.yim0327.spring_chat.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import study.yim0327.spring_chat.util.ApiResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /** 잘못된 파라미터 (서비스/도메인) */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<?>> handleIllegalArgument(IllegalArgumentException e) {
+        return ResponseEntity
+                .badRequest() // 400 BAD REQUEST
+                .body(ApiResponse.failure(e.getMessage()));
+    }
+
+    /**  DTO @Valid 검증 실패 */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult()
+                .getFieldErrors()   // 발생한 모든 오류들의 리스트
+                .get(0)             // 첫 번째 오류만 사용
+                .getDefaultMessage();
+
+        return ResponseEntity
+                .badRequest() // 400 BAD REQUEST
+                .body(ApiResponse.failure(message));
+    }
+
+    /** 그 외 예상 못한 모든 에러 */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR) // 500 INTERNAL_SERVER_ERROR
+                .body(ApiResponse.failure("서버 오류가 발생했습니다."));
+    }
+
+}

--- a/src/main/java/study/yim0327/spring_chat/repository/ActiveNicknameRepository.java
+++ b/src/main/java/study/yim0327/spring_chat/repository/ActiveNicknameRepository.java
@@ -1,0 +1,12 @@
+package study.yim0327.spring_chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import study.yim0327.spring_chat.entity.ActiveNickname;
+
+@Repository
+public interface ActiveNicknameRepository extends JpaRepository<ActiveNickname, Long> {
+
+    // 같은 방 안에서 닉네임 중복 체크
+    boolean existsByChatRoom_IdAndActiveNickname(Long roomId, String activeNickname);
+}

--- a/src/main/java/study/yim0327/spring_chat/repository/ChatRoomRepository.java
+++ b/src/main/java/study/yim0327/spring_chat/repository/ChatRoomRepository.java
@@ -1,0 +1,9 @@
+package study.yim0327.spring_chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import study.yim0327.spring_chat.entity.ChatRoom;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/study/yim0327/spring_chat/repository/ChatRoomRepository.java
+++ b/src/main/java/study/yim0327/spring_chat/repository/ChatRoomRepository.java
@@ -6,4 +6,6 @@ import study.yim0327.spring_chat.entity.ChatRoom;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    boolean existsByRoomName(String roomName);
 }

--- a/src/main/java/study/yim0327/spring_chat/repository/SessionRepository.java
+++ b/src/main/java/study/yim0327/spring_chat/repository/SessionRepository.java
@@ -1,0 +1,9 @@
+package study.yim0327.spring_chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import study.yim0327.spring_chat.entity.Session;
+
+@Repository
+public interface SessionRepository extends JpaRepository<Session, Long> {
+}

--- a/src/main/java/study/yim0327/spring_chat/service/ChatRoomService.java
+++ b/src/main/java/study/yim0327/spring_chat/service/ChatRoomService.java
@@ -1,0 +1,25 @@
+package study.yim0327.spring_chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import study.yim0327.spring_chat.dto.ChatRoomCreateRequestDto;
+import study.yim0327.spring_chat.dto.ChatRoomCreateResponseDto;
+import study.yim0327.spring_chat.dto.ChatRoomSearchResponseDto;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatRoomService {
+
+    public ChatRoomCreateResponseDto createRoom(ChatRoomCreateRequestDto request) {
+        throw new IllegalArgumentException("Not implemented");
+    }
+
+    public List<ChatRoomSearchResponseDto> getAllRooms() {
+        throw new IllegalArgumentException("Not implemented");
+    }
+
+}

--- a/src/main/java/study/yim0327/spring_chat/service/ChatRoomService.java
+++ b/src/main/java/study/yim0327/spring_chat/service/ChatRoomService.java
@@ -6,20 +6,52 @@ import org.springframework.transaction.annotation.Transactional;
 import study.yim0327.spring_chat.dto.ChatRoomCreateRequestDto;
 import study.yim0327.spring_chat.dto.ChatRoomCreateResponseDto;
 import study.yim0327.spring_chat.dto.ChatRoomSearchResponseDto;
+import study.yim0327.spring_chat.entity.ChatRoom;
+import study.yim0327.spring_chat.repository.ChatRoomRepository;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class ChatRoomService {
 
+    private final ChatRoomRepository chatRoomRepository;
+
+    /** 채팅방 생성 */
     public ChatRoomCreateResponseDto createRoom(ChatRoomCreateRequestDto request) {
-        throw new IllegalArgumentException("Not implemented");
+        String roomName = request.getRoomName();
+
+        if (chatRoomRepository.existsByRoomName(roomName)) {
+            throw new IllegalArgumentException("이미 존재하는 채팅방 이름입니다.");
+        }
+
+        // 랜덤 roomCode 8자 생성
+        String roomCode = UUID.randomUUID().toString().substring(0, 8);
+
+        ChatRoom room = ChatRoom.create(roomName, roomCode);
+        ChatRoom saved = chatRoomRepository.save(room);
+
+        return new ChatRoomCreateResponseDto(
+                saved.getId(),
+                saved.getRoomName(),
+                saved.getRoomCode(),
+                saved.getCreatedAt()
+        );
     }
 
+    /** 전체 채팅방 목록 조회 */
     public List<ChatRoomSearchResponseDto> getAllRooms() {
-        throw new IllegalArgumentException("Not implemented");
+        return chatRoomRepository.findAll().stream()
+                .map(room -> new ChatRoomSearchResponseDto(
+                        room.getId(),
+                        room.getRoomName(),
+                        room.getRoomCode(),
+                        room.getCreatedAt(),
+                        room.getUpdatedAt()
+                ))
+                .toList();
     }
 
 }

--- a/src/main/java/study/yim0327/spring_chat/service/SessionService.java
+++ b/src/main/java/study/yim0327/spring_chat/service/SessionService.java
@@ -1,15 +1,64 @@
 package study.yim0327.spring_chat.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import study.yim0327.spring_chat.dto.NicknameRegisterResponseDto;
+import study.yim0327.spring_chat.entity.ActiveNickname;
+import study.yim0327.spring_chat.entity.ChatRoom;
+import study.yim0327.spring_chat.entity.Session;
+import study.yim0327.spring_chat.repository.ActiveNicknameRepository;
+import study.yim0327.spring_chat.repository.ChatRoomRepository;
+import study.yim0327.spring_chat.repository.SessionRepository;
+
+import java.util.UUID;
 
 @Service
+@RequiredArgsConstructor
 public class SessionService {
+
+    private final SessionRepository sessionRepository;
+    private final ActiveNicknameRepository activeNicknameRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     @Transactional
     public NicknameRegisterResponseDto register(Long roomId, String nickname) {
-        throw new IllegalArgumentException("Not implemented");
+        validateNickname(nickname);
+
+        ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방입니다: id=" + roomId));
+
+        // 방 안에서 닉네임 중복 체크
+        if (activeNicknameRepository.existsByChatRoom_IdAndActiveNickname(roomId, nickname)) {
+            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+        }
+
+        // 활성 닉네임 생성 & 저장
+        ActiveNickname activeNickname = ActiveNickname.create(nickname, room);
+        activeNicknameRepository.save(activeNickname);
+
+        // 고유 clientId 생성 (브라우저 탭 식별용)
+        String clientId = UUID.randomUUID().toString();
+
+        // 세션 생성 & 저장
+        Session session = Session.create(clientId, activeNickname);
+        sessionRepository.save(session);
+
+        return new NicknameRegisterResponseDto(
+                session.getId(),
+                session.getClientId(),
+                room.getId(),
+                activeNickname.getActiveNickname()
+        );
+    }
+
+    private void validateNickname(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new IllegalArgumentException("닉네임은 비어 있을 수 없습니다.");
+        }
+        if (nickname.length() > 20) {
+            throw new IllegalArgumentException("닉네임은 20자 이하만 가능합니다.");
+        }
     }
 
 }

--- a/src/main/java/study/yim0327/spring_chat/service/SessionService.java
+++ b/src/main/java/study/yim0327/spring_chat/service/SessionService.java
@@ -1,0 +1,15 @@
+package study.yim0327.spring_chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import study.yim0327.spring_chat.dto.NicknameRegisterResponseDto;
+
+@Service
+public class SessionService {
+
+    @Transactional
+    public NicknameRegisterResponseDto register(Long roomId, String nickname) {
+        throw new IllegalArgumentException("Not implemented");
+    }
+
+}

--- a/src/main/java/study/yim0327/spring_chat/util/ApiResponse.java
+++ b/src/main/java/study/yim0327/spring_chat/util/ApiResponse.java
@@ -1,0 +1,35 @@
+package study.yim0327.spring_chat.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 값 필드는 JSON에서 제외
+public class ApiResponse<T> {
+    private boolean success;
+    private String message;
+    private T data;
+
+    // 성공 응답 (데이터 있음)
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, message, data);
+    }
+
+    // 성공 응답 (데이터 없음)
+    public static <T> ApiResponse<T> success(String message) {
+        return new ApiResponse<>(true, message, null);
+    }
+
+    // 메시지 없이 데이터만 있는 성공 응답
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, null, data);
+    }
+
+    // 실패 응답
+    public static <T> ApiResponse<T> failure(String message) {
+        return new ApiResponse<>(false, message, null);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## 채팅방 생성/조회 API 기본 구조 추가
- ChatRoomController 생성/조회 로직 구현
- ChatRoomService 구조 작성 및 메서드 선언 (createRoom, getAllRooms / 미구현)
- ChatRoomCreateRequestDto 생성 (방 생성 요청)
- ChatRoomCreateResponseDto 생성 (방 생성 응답)
- ChatRoomSearchResponseDto 생성 (방 목록 조회 응답)

## 채팅방 생성/조회 서비스 로직 구현
- ChatRoomService에 채팅방 생성(createRoom) 및 전체 조회(getAllRooms) 기능 구현
- ChatRoom 엔티티에 정적 팩토리 메서드 create 추가
- ChatRoomRepository에 existsByRoomName() 추가하여 방 이름 중복 검증 처리
